### PR TITLE
Comments 04 11 2024

### DIFF
--- a/Main_nssm_version.py
+++ b/Main_nssm_version.py
@@ -229,10 +229,10 @@ def model_loading():
         nssm_node.load_state_dict(torch.load('nssm_model_node.pth'), strict=False)
         print("Model loaded successfully.")
     
-    dynamics_model = System([nssm_node], name='system', nsteps=nsteps)
-    dynamics_model.nstep_key = 'U'
+    #dynamics_model = System([nssm_node], name='system', nsteps=nsteps)
+    #dynamics_model.nstep_key = 'U'
     
-    return dynamics_model
+    return nssm_node
 
 
 # nssm_node = model_loading()


### PR DESCRIPTION
@DanielBekker1  
The error seems to arise due to the way the DictDataSets are being declared. This is neuromancer-specific so I don't understand it completely, but to stay safe, try to always declare those DictDatasets the same way as it is done in the neuromancer examples or like you have them in the NSSM file. I also modified the way you load the nssm_node since you where wrapping the node into a system and then again wrapping that system within the closed-loop system, that might bring unexpected behaviour.

The "xn" data should have only 1 value per batch as it needs only the initial condition. Because of this, you just need an initial condition in xn to start the training of the control policy. I think you also don't need the "U" values, as these would be generated by the control policy while training. Try making drawings of what kind of input you would need for the training of the cl_system and what kind for the inference (usage) of it.

Lastly, the testing of the control policy would need to be reformulated to comply with the expected input keys.

